### PR TITLE
Modify settings

### DIFF
--- a/cli_configure.go
+++ b/cli_configure.go
@@ -238,9 +238,12 @@ func (c *configure) initconfig() error {
 			return errors.New(fmt.Sprintf("Error parsing HTTP response body:\n%s\n\nIf you just launched the instance, please give it few more seconds to get ready and try again.", content))
 		}
 
-		if em.Error == "password-error" {
-			fmt.Printf("Message in initconfig: %s\n", em.Message)
-			return nil
+		if em.Error == "password-error" && em.Message == "Password already set." {
+			fmt.Printf("Message in initconfig: %s\nRunning 'Modify settings' instead.\n", em.Message)
+			err := c.sendconfig()
+			if err != nil {
+				return err
+			}
 		} else {
 			return errors.New(fmt.Sprintf("Error in initconfig: %s - %s\n", em.Error, em.Message))
 		}
@@ -488,20 +491,6 @@ func (c *configure) checkprogress() error {
 	} else {
 		fmt.Println("Status: " + s.Status)
 		return errors.New("Failed to configure " + c.domain + " :(")
-	}
-
-	return nil
-}
-
-func (c *configure) updateconfig() error {
-	err := c.sendconfig()
-	if err != nil {
-		return err
-	}
-
-	err = c.applyconfig()
-	if err != nil {
-		return err
 	}
 
 	return nil

--- a/cli_configure.go
+++ b/cli_configure.go
@@ -233,7 +233,11 @@ func (c *configure) initconfig() error {
 			Error   string `json:"error"`
 			Message string `json:"message"`
 		}{}
-		json.Unmarshal(content, em)
+		err := json.Unmarshal(content, em)
+		if err != nil {
+			return errors.New(fmt.Sprintf("Error parsing HTTP response body:\n%s\n\nIf you just launched the instance, please give it few more seconds to get ready and try again.", content))
+		}
+
 		if em.Error == "password-error" {
 			fmt.Printf("Message in initconfig: %s\n", em.Message)
 			return nil
@@ -382,19 +386,19 @@ func (c *configure) addkey() error {
 	}
 
 	if len(content) > 0 {
-		kp := []struct {
+		kp := &[]struct {
 			Key         string `json:"key"`
 			PrettyPrint string `json:"pretty-print"`
 			Comment     string `json:"comment"`
 		}{}
 
-		err := json.Unmarshal(content, &kp)
+		err := json.Unmarshal(content, kp)
 		if err != nil {
-			return err
+			return errors.New(fmt.Sprintf("Error parsing HTTP response body:\n%s\n", content))
 		}
 
 		fmt.Println("Keys:")
-		for _, v := range kp {
+		for _, v := range *kp {
 			fmt.Printf("%s - %s\n", v.PrettyPrint, v.Comment)
 		}
 	}
@@ -458,7 +462,7 @@ func (c *configure) checkprogress() error {
 
 		err = json.Unmarshal(content, s)
 		if err != nil {
-			return err
+			return errors.New(fmt.Sprintf("Error parsing HTTP response body:\n%s\n", content))
 		}
 
 		if s.Status != "running" {


### PR DESCRIPTION
- If the instance is already initialized (`Password already set.` message returned) when running `POST /setup/api/start`, fallback to `PUT /setup/api/settings`
- Better error message in some methods